### PR TITLE
Add a label for work in progress

### DIFF
--- a/_settings.yml
+++ b/_settings.yml
@@ -77,6 +77,10 @@ labels:
   - name: good first issue
     color: 0000cc
     description: Suitable for new contributers to tackle.
+    
+  - name: work in progress
+    color: 660000
+    description: Still working on it, not ready to merge
 
 
 # Milestones: define milestones for Issues and Pull Requests


### PR DESCRIPTION
I want to enable something like Mergify, but before we do that, we need a way to identify PRs that are not ready to be automatically merged. This label would be a natural candidate for something like that.