### PR TITLE
Add a label for hacktoberfest issues

### DIFF
--- a/_settings.yml
+++ b/_settings.yml
@@ -82,6 +82,9 @@ labels:
     color: 660000
     description: Still working on it, not ready to merge
 
+  - name: hacktoberfest
+    color: fbca04
+    description: Issue suitable for Hacktoberfest contributors (https://hacktoberfest.digitalocean.com/)
 
 # Milestones: define milestones for Issues and Pull Requests
 milestones:


### PR DESCRIPTION
DigitalOcean runs a yearly event promoting contributions to OSS. One way to attract contributors is to label suitable issues with a `hacktoberfest` label, which people can then find (in theory, in practice there are currently over 26k open issues with the label).

I'm adding the label here, so that it's readily available for adding on issues that might be suitable across all our repos.

See more at https://hacktoberfest.digitalocean.com/